### PR TITLE
update build script for gitinfo last mod footer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -133,6 +133,12 @@ function fMergeContent() {
             ln ${_ln_opt} $(pwd)/${xxx} ${BUILD_DIR}/${xxx}
         fi
     done
+
+    # This soft link makes the git info available for hugo to populate the date with git hash in the footer.
+    # Note that common files coming from axway-open-docs-common will not have this information and the pages
+    # will use the "date" value at the top of the page.
+    ln ${_ln_opt} $(pwd)/.git ${BUILD_DIR}/.git
+
     echo "[INFO] Following symlinks were created:"
     for xxx in `find $(basename ${BUILD_DIR}) -type l`;do
         echo "[INFO]    |- ${xxx}"


### PR DESCRIPTION
Thank you for your contribution.

## Describe the changes

When we moved the projects into microsites, we realized the footer was not displaying the proper details. Wing updated the build script to properly render the gitinfo (Last modified date with PR # and commit message) in the published output of the footer on each page.  

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [x] Does not have conflicts with the base branch
* [x] Is clear and complete
* [x] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [x] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [x] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [x] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [x] Does not contain typos, grammatical errors, etc.
* [x] Does not expose any sensitive information
* [x] Passes the Markdown linter rules (automated via CI check)
* [x] Does not contain broken links
* [x] Is discoverable and navigable
