### PR TITLE
Markdown issues with two headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ public/
 resources/
 node_modules/
 tech-doc-hugo
+.hugo_build.lock
 

--- a/content/en/docs/shared_services/supportapi/methods/create_case.md
+++ b/content/en/docs/shared_services/supportapi/methods/create_case.md
@@ -16,7 +16,7 @@ Create a new support case or customer enhancement request.
 Create Case requests come in two forms: [simple](#create-case-simple) and [full](#create-case-full).
 Simple requests allow you to send just the case information. Full requests allow you to attach files.
 
-### Create Case - Simple
+### Create Case Simple
 
 Send the case information directly as the HTTP entity-body.
 
@@ -56,7 +56,7 @@ Send the case information directly as the HTTP entity-body.
 }
 ```
 
-### Create Case - Full
+### Create Case Full
 
 Allows for optionally attaching files at the time of case creation.
 {{% alert title="Note" %}}


### PR DESCRIPTION
Thank you for your contribution.

## Describe the changes

Two heading that contained "-" dashes were causing the Jenkins build to fail even though the markdown checks in the PR passed. The dashes were removed from the headings. 

## Deploy preview link

Please add the deploy preview link to the **specific page** that you've changed.

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
